### PR TITLE
lathe tax code mortis

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -89,7 +89,7 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "aA" = (
-/obj/machinery/rnd/production/protolathe/department/engineering/no_tax,
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 9
 	},

--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -2354,7 +2354,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/circuitboard/machine/protolathe/offstation,
 /obj/effect/spawner/random/engineering/toolbox,
-/obj/item/circuitboard/machine/circuit_imprinter/department/no_tax,
+/obj/item/circuitboard/machine/circuit_imprinter/department,
 /obj/item/circuitboard/machine/rtg/advanced,
 /obj/item/circuitboard/machine/rtg/advanced,
 /obj/item/circuitboard/machine/rtg/advanced,

--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -15,11 +15,6 @@
 ///Paygrade for Heads of Staff.
 #define PAYCHECK_COMMAND 100
 
-//How many credits a player is charged if they print something from a departmental lathe they shouldn't have access to.
-#define LATHE_TAX 10
-//How much POWER a borg's cell is taxed if they print something from a departmental lathe.
-#define SILICON_LATHE_TAX 2000
-
 #define STATION_TARGET_BUFFER 25
 
 

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -235,10 +235,6 @@
 	name = "Departmental Protolathe - Engineering"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/rnd/production/protolathe/department/engineering
-
-/obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
-	build_path = /obj/machinery/rnd/production/protolathe/department/engineering/no_tax
-
 /obj/item/circuitboard/machine/rtg
 	name = "RTG"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -28,9 +28,6 @@
 	/// What color is this machine's stripe? Leave null to not have a stripe.
 	var/stripe_color = null
 
-	/// Does this charge the user's ID on fabrication?
-	var/charges_tax = TRUE
-
 /obj/machinery/rnd/production/Initialize(mapload)
 	. = ..()
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -271,36 +271,6 @@
 			say("Not enough reagents to complete prototype[print_quantity > 1? "s" : ""].")
 			return FALSE
 
-	// Charge the lathe tax at least once per ten items.
-	var/total_cost = LATHE_TAX * max(round(print_quantity / 10), 1)
-
-	if(!charges_tax)
-		total_cost = 0
-
-	if(isliving(usr))
-		var/mob/living/user = usr
-		var/obj/item/card/id/card = user.get_idcard(TRUE)
-
-		if(!card && istype(user.pulling, /obj/item/card/id))
-			card = user.pulling
-
-		if(card && card.registered_account)
-			var/datum/bank_account/our_acc = card.registered_account
-			if(our_acc.account_job.departments_bitflags & allowed_department_flags)
-				total_cost = 0 // We are not charging crew for printing their own supplies and equipment.
-
-	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)
-		say("Insufficient funds to complete prototype. Please present a holochip or valid ID card.")
-		return FALSE
-
-	if(iscyborg(usr))
-		var/mob/living/silicon/robot/borg = usr
-
-		if(!borg.cell)
-			return FALSE
-
-		borg.cell.use(SILICON_LATHE_TAX)
-
 	materials.mat_container.use_materials(efficient_mats, print_quantity)
 	materials.silo_log(src, "built", -print_quantity, "[design.name]", efficient_mats)
 

--- a/code/modules/research/machinery/circuit_imprinter.dm
+++ b/code/modules/research/machinery/circuit_imprinter.dm
@@ -21,4 +21,3 @@
 	desc = "Manufactures circuit boards for the construction of machines. Its ancient construction may limit its ability to print all known technology."
 	allowed_buildtypes = AWAY_IMPRINTER
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/offstation
-	charges_tax = FALSE

--- a/code/modules/research/machinery/departmental_protolathe.dm
+++ b/code/modules/research/machinery/departmental_protolathe.dm
@@ -12,10 +12,6 @@
 	stripe_color = "#EFB341"
 	payment_department = ACCOUNT_ENG
 
-/obj/machinery/rnd/production/protolathe/department/engineering/no_tax
-	circuit = /obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
-	charges_tax = FALSE
-
 /obj/machinery/rnd/production/protolathe/department/service
 	name = "department protolathe (Service)"
 	allowed_department_flags = DEPARTMENT_BITFLAG_SERVICE

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -23,4 +23,3 @@
 	desc = "Converts raw materials into useful objects. Its ancient construction may limit its ability to print all known technology."
 	circuit = /obj/item/circuitboard/machine/protolathe/offstation
 	allowed_buildtypes = AWAY_LATHE
-	charges_tax = FALSE

--- a/modular_skyrat/master_files/code/modules/research/machinery/departmental_circuit_imprinter.dm
+++ b/modular_skyrat/master_files/code/modules/research/machinery/departmental_circuit_imprinter.dm
@@ -1,5 +1,0 @@
-/obj/item/circuitboard/machine/circuit_imprinter/department/no_tax
-	build_path = /obj/machinery/rnd/production/circuit_imprinter/department/no_tax
-
-/obj/machinery/rnd/production/circuit_imprinter/department/no_tax
-	charges_tax = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I came across lathe tax code while helping ed, and then tracked down the entire ugly snarl and expunged it from the game.

## How This Contributes To The Skyrat Roleplay Experience

The removal of pointless credit sinks will create nothing but joy for the people playing on this codebase.

## Proof of Testing

Done in private, was able to use the metastation cargo protolathe without being dinged for money.

## Changelog

:cl:

del: lathe tax
balance; no more pointless charging
admin; this might've upset off-station lathes but I doubt it mostly?

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
